### PR TITLE
finalize_confirmation(): use action as tag= param

### DIFF
--- a/src/webapi.py
+++ b/src/webapi.py
@@ -489,7 +489,7 @@ class SteamWebAPI:
     ) -> Dict[str, Any]:
         extra_params = {'cid': trade_id, 'ck': trade_key, 'op': action}
         server_time = int(time.time()) - time_offset
-        params = await self._new_query(server_time, deviceid, steamid, identity_secret, 'conf')
+        params = await self._new_query(server_time, deviceid, steamid, identity_secret, action)
 
         async with self.session.get(
                 f'{self.mobileconf_url}/ajaxop',


### PR DESCRIPTION
Send tag=allow or tag=cancel when accepting or rejecting a confirmation, rather than incorrectly sending tag=conf, which I believe should only be done when retrieving a list of confirmations.

References:
https://github.com/geel9/SteamAuth/blob/master/SteamAuth/SteamGuardAccount.cs
https://github.com/luop90/node-steam-mobile-confirmations/blob/master/index.js
https://github.com/bukson/steampy/blob/master/steampy/confirmation.py
https://github.com/Zwork101/steam-trade/blob/master/pytrade/confirmations.py
https://github.com/i-galetsky-gs-by/steamcommunity-mobile-confirmations/blob/master/index.js
https://github.com/DoctorMcKay/node-steamcommunity/blob/master/components/confirmations.js

Fixes #7